### PR TITLE
QPID-7391: fix the routing key / subject handling when responding to received messages in qpid-receive

### DIFF
--- a/src/tests/qpid-receive.cpp
+++ b/src/tests/qpid-receive.cpp
@@ -267,6 +267,15 @@ int main(int argc, char ** argv)
                         s.setCapacity(opts.capacity);
                         replyTo[msg.getReplyTo().str()] = s;
                     }
+                    if (!msg.getSubject().empty()) {
+                        msg.setSubject(msg.getReplyTo().getSubject());
+                        if (msg.getProperties().count("qpid.subject") == 1) {
+                            msg.setProperty("qpid.subject", msg.getReplyTo().getSubject());
+                        }
+                        if (msg.getProperties().count("x-amqp-0-10.routing-key") == 1) {
+                            msg.setProperty("x-amqp-0-10.routing-key", msg.getReplyTo().getSubject());
+                        }
+                    }
                     msg.setReplyTo(Address(opts.replyto));
                     s.send(msg);
                 }


### PR DESCRIPTION
The proposed patch uses the routing key form the reply-to address as new subject, qpid.subject and x-amqp-0-10.routing-key. This makes sure that the response message will be actually sent according to the specified reply-to address.