### PR TITLE
QPID-7702: use SWIG_fail instead of returning on error

### DIFF
--- a/bindings/qpid/python/qpid_messaging.i
+++ b/bindings/qpid/python/qpid_messaging.i
@@ -134,7 +134,7 @@ QPID_EXCEPTION(UnauthorizedAccess, SessionError)
     Py_END_ALLOW_THREADS;
     if (!error.empty()) {
         PyErr_SetString(pExceptionType, error.c_str());
-        return NULL;
+        SWIG_fail;
     }
 }
 


### PR DESCRIPTION
This change should prevent many of the wrapper-related resource leaks found by Coverity.