### PR TITLE
Highly sketchy fixes for initialization warnings

### DIFF
--- a/src/qpid/broker/Selector.cpp
+++ b/src/qpid/broker/Selector.cpp
@@ -108,7 +108,7 @@ MessageSelectorEnv::MessageSelectorEnv(const Message& m) :
 
 const Value MessageSelectorEnv::specialValue(const string& id) const
 {
-    Value v;
+    Value v = Value();
     // TODO: Just use a simple if chain for now - improve this later
     if ( id=="delivery_mode" ) {
         v = msg.getEncoding().isPersistent() ? PERSISTENT : NON_PERSISTENT;
@@ -165,8 +165,6 @@ const Value MessageSelectorEnv::specialValue(const string& id) const
             returnedStrings.push_back(new string(jmsType));
             v = returnedStrings[returnedStrings.size()-1];
         }
-    } else {
-        v = Value();
     }
     return v;
 }

--- a/src/qpid/broker/SelectorExpression.cpp
+++ b/src/qpid/broker/SelectorExpression.cpp
@@ -1036,7 +1036,7 @@ Expression* unaryArithExpression(Tokeniser& tokeniser)
 Expression* parseExactNumeric(const Token& token, bool negate)
 {
     int base = 0;
-    string s;
+    string s("");
     std::remove_copy(token.val.begin(), token.val.end(), std::back_inserter(s), '_');
     if (s[1]=='b' || s[1]=='B') {
         base = 2;

--- a/src/qpid/broker/SelectorToken.h
+++ b/src/qpid/broker/SelectorToken.h
@@ -69,7 +69,8 @@ struct Token {
     std::string val;
     std::string::const_iterator tokenStart;
 
-    Token()
+    Token() :
+        type()
     {}
 
     Token(TokenType t, const std::string& v) :


### PR DESCRIPTION
Don't merge this.

This commit gets things building on Fedora 26, addressing QPID-7893 [1].  I'm stabbing in the dark when it comes to C++ initialization.  Please help me determine if these changes are correct and harmless.

[1]: https://issues.apache.org/jira/browse/QPID-7893