### PR TITLE
Assorted C++ build fixes for review

### DIFF
--- a/CMakeModules/FindSWIG.cmake
+++ b/CMakeModules/FindSWIG.cmake
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+include(${CMAKE_ROOT}/Modules/FindSWIG.cmake)
+
+if (NOT COMMAND swig_add_library)
+  macro (SWIG_ADD_LIBRARY name)
+    set(options "")
+    set(oneValueArgs LANGUAGE TYPE)
+    set(multiValueArgs SOURCES)
+    cmake_parse_arguments(_SAM "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if (NOT DEFINED _SAM_LANGUAGE)
+      message(FATAL_ERROR "SWIG_ADD_LIBRARY: Missing LANGUAGE argument")
+    endif ()
+
+    if (NOT DEFINED _SAM_SOURCES)
+      message(FATAL_ERROR "SWIG_ADD_LIBRARY: Missing SOURCES argument")
+    endif ()
+
+    if (DEFINED _SAM_TYPE AND NOT _SAM_LANGUAGE STREQUAL "module")
+      message(FATAL_ERROR "SWIG_ADD_LIBRARY: This fallback impl of swig_add_library supports the module type only")
+    endif ()
+
+    swig_add_module(${name} ${_SAM_LANGUAGE} ${_SAM_SOURCES})
+  endmacro ()
+endif (NOT COMMAND swig_add_library)

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -123,22 +123,28 @@ if (SWIG_FOUND)
 
   if (BUILD_BINDING_RUBY)
       message(STATUS "Building Ruby bindings")
-      execute_process(COMMAND ${RUBY_EXECUTABLE} -r rbconfig -e "puts RbConfig::CONFIG['prefix']"
-                      OUTPUT_VARIABLE RUBY_PREFIX
-                      OUTPUT_STRIP_TRAILING_WHITESPACE)
-      string(REPLACE ${RUBY_PREFIX} ${CMAKE_INSTALL_PREFIX} RUBY_PFX_ARCH_DIR ${RUBY_SITEARCH_DIR})
-#     string(REPLACE ${RUBY_PREFIX} ${CMAKE_INSTALL_PREFIX} RUBY_PFX_ARCH_DIR ${RUBY_ARCH_DIR})
+      if (NOT RUBY_PFX_ARCH_DIR)
+        execute_process(COMMAND ${RUBY_EXECUTABLE} -r rbconfig -e "puts RbConfig::CONFIG['prefix']"
+                        OUTPUT_VARIABLE RUBY_PREFIX
+                        OUTPUT_STRIP_TRAILING_WHITESPACE)
+        string(REPLACE ${RUBY_PREFIX} ${CMAKE_INSTALL_PREFIX} RUBY_PFX_ARCH_DIR ${RUBY_SITEARCH_DIR})
+      endif (NOT RUBY_PFX_ARCH_DIR)
+
       add_subdirectory(qpid/ruby)
       add_subdirectory(qmf2/ruby)
   endif (BUILD_BINDING_RUBY)
 
   if (BUILD_BINDING_PERL)
       message(STATUS "Building Perl bindings")
-      execute_process(COMMAND ${PERL_EXECUTABLE} "-V::prefix:"
-                      OUTPUT_VARIABLE QPERL_PREFIX
-                      OUTPUT_STRIP_TRAILING_WHITESPACE)
-      string(REGEX REPLACE "'(.*)'" "\\1" PERL_PREFIX ${QPERL_PREFIX})
-      string(REPLACE ${PERL_PREFIX} ${CMAKE_INSTALL_PREFIX} PERL_PFX_ARCHLIB ${PERL_ARCHLIB})
+      if (NOT PERL_PFX_ARCHLIB)
+        execute_process(COMMAND ${PERL_EXECUTABLE} "-V::prefix:"
+                        OUTPUT_VARIABLE QPERL_PREFIX
+                        OUTPUT_STRIP_TRAILING_WHITESPACE)
+        string(REGEX REPLACE "'(.*)'" "\\1" PERL_PREFIX ${QPERL_PREFIX})
+        string(REPLACE ${PERL_PREFIX} ${CMAKE_INSTALL_PREFIX} PERL_PFX_ARCHLIB ${PERL_ARCHLIB})
+      else (NOT PERL_PFX_ARCHLIB)
+        message(STATUS "*** Using Perl language directory: ${PERL_PFX_ARCHLIB}")
+      endif (NOT PERL_PFX_ARCHLIB)
 
       add_subdirectory(qpid/perl)
   endif (BUILD_BINDING_PERL)

--- a/bindings/qmf2/python/CMakeLists.txt
+++ b/bindings/qmf2/python/CMakeLists.txt
@@ -32,7 +32,7 @@ list(APPEND SWIG_MODULE_cqmf2_EXTRA_DEPS
     ${CMAKE_SOURCE_DIR}/include/qmf/qmf2.i
     ${CMAKE_SOURCE_DIR}/include/qpid/swig_python_typemaps.i
 )
-swig_add_module(cqmf2 python ${CMAKE_CURRENT_SOURCE_DIR}/cqmf2.i)
+swig_add_library(cqmf2 LANGUAGE python SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/cqmf2.i)
 swig_link_libraries(cqmf2 qmf2 qpidmessaging qpidtypes ${PYTHON_LIBRARIES})
 
 set_source_files_properties(${swig_generated_file_fullname} PROPERTIES COMPILE_FLAGS "${NOSTRICT_ALIASING}")

--- a/bindings/qmf2/ruby/CMakeLists.txt
+++ b/bindings/qmf2/ruby/CMakeLists.txt
@@ -36,7 +36,7 @@ list(APPEND SWIG_MODULE_cqmf2_ruby_EXTRA_DEPS
     ${CMAKE_SOURCE_DIR}/include/qmf/qmf2.i
     ${CMAKE_SOURCE_DIR}/include/qpid/swig_ruby_typemaps.i
 )
-swig_add_module(cqmf2_ruby ruby ${CMAKE_CURRENT_SOURCE_DIR}/ruby.i)
+swig_add_library(cqmf2_ruby LANGUAGE ruby SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/ruby.i)
 swig_link_libraries(cqmf2_ruby qmf2 qpidmessaging qpidtypes ${RUBY_LIBRARY})
 
 ##----------------------------------

--- a/bindings/qpid/perl/CMakeLists.txt
+++ b/bindings/qpid/perl/CMakeLists.txt
@@ -43,13 +43,18 @@ include_directories(${PERL_INCLUDE_PATH}
 # it's coming from a version of Cmake < 2.8
 install(TARGETS ${SWIG_MODULE_cqpid_perl_REAL_NAME}
         RENAME cqpid_perl.so
-        DESTINATION ${PERL_PFX_ARCHLIB}
+        DESTINATION ${PERL_PFX_ARCHLIB}/auto/cqpid_perl
         COMPONENT ${QPID_COMPONENT_CLIENT}
 )
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cqpid_perl.pm
-              ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE
-              ${CMAKE_CURRENT_SOURCE_DIR}/Makefile.PL
+              ${CMAKE_CURRENT_SOURCE_DIR}/lib/qpid_messaging.pm
+              ${CMAKE_CURRENT_SOURCE_DIR}/lib/qpid.pm
         DESTINATION ${PERL_PFX_ARCHLIB}
         COMPONENT ${QPID_COMPONENT_CLIENT}
         )
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/lib/qpid
+  DESTINATION ${PERL_PFX_ARCHLIB}
+  COMPONENT ${QPID_COMPONENT_CLIENT}
+  )

--- a/bindings/qpid/perl/CMakeLists.txt
+++ b/bindings/qpid/perl/CMakeLists.txt
@@ -28,7 +28,7 @@ list(APPEND SWIG_MODULE_cqpid_perl_EXTRA_DEPS
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../include/qpid/qpid.i
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../include/qpid/swig_perl_typemaps.i
 )
-swig_add_module(cqpid_perl perl ${CMAKE_CURRENT_SOURCE_DIR}/perl.i)
+swig_add_library(cqpid_perl LANGUAGE perl SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/perl.i)
 swig_link_libraries(cqpid_perl qpidmessaging qpidtypes ${PERL_LIBRARY})
 set_source_files_properties(${swig_generated_file_fullname} PROPERTIES COMPILE_FLAGS "${NOSTRICT_ALIASING}")
 

--- a/bindings/qpid/python/CMakeLists.txt
+++ b/bindings/qpid/python/CMakeLists.txt
@@ -32,7 +32,7 @@ list(APPEND SWIG_MODULE_qpid_messaging_EXTRA_DEPS
     ${CMAKE_SOURCE_DIR}/include/qpid/qpid.i
     ${CMAKE_SOURCE_DIR}/include/qpid/swig_python_typemaps.i
 )
-swig_add_module(qpid_messaging python ${CMAKE_CURRENT_SOURCE_DIR}/qpid_messaging.i)
+swig_add_library(qpid_messaging LANGUAGE python SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/qpid_messaging.i)
 swig_link_libraries(qpid_messaging qpidmessaging qpidtypes ${PYTHON_LIBRARIES})
 set_source_files_properties(${swig_generated_file_fullname} PROPERTIES COMPILE_FLAGS "${NOSTRICT_ALIASING}")
 

--- a/bindings/qpid/ruby/CMakeLists.txt
+++ b/bindings/qpid/ruby/CMakeLists.txt
@@ -45,7 +45,7 @@ list(APPEND SWIG_MODULE_cqpid_ruby_EXTRA_DEPS
     ${CMAKE_SOURCE_DIR}/include/qpid/qpid.i
     ${CMAKE_SOURCE_DIR}/include/qpid/swig_ruby_typemaps.i
 )
-swig_add_module(cqpid_ruby ruby ${CMAKE_CURRENT_SOURCE_DIR}/ruby.i)
+swig_add_library(cqpid_ruby LANGUAGE ruby SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/ruby.i)
 swig_link_libraries(cqpid_ruby qpidmessaging qpidtypes ${RUBY_LIBRARY})
 
 set_source_files_properties(${swig_generated_file_fullname} PROPERTIES COMPILE_FLAGS "${NOSTRICT_ALIASING}")

--- a/bindings/qpid/ruby/CMakeLists.txt
+++ b/bindings/qpid/ruby/CMakeLists.txt
@@ -59,6 +59,11 @@ install(TARGETS ${SWIG_MODULE_cqpid_ruby_REAL_NAME}
       COMPONENT ${QPID_COMPONENT_CLIENT}
 )
 
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/lib
+        DESTINATION ${RUBY_PFX_ARCH_DIR}
+        COMPONENT ${QPID_COMPONENT_CLIENT}
+        )
+
 add_custom_command(OUTPUT ${GEM_BINDINGS_SOURCE_FILE}
                    COMMAND cp ${swig_generated_file_fullname} ${GEM_BINDINGS_SOURCE_FILE}
                    DEPENDS ${swig_generated_file_fullname}

--- a/src/amqp.cmake
+++ b/src/amqp.cmake
@@ -22,7 +22,7 @@
 find_package(Proton 0.7)
 
 set (amqp_default ${amqp_force})
-set (maximum_version 0.17)
+set (maximum_version 0.18)
 if (Proton_FOUND)
     if (Proton_VERSION VERSION_GREATER ${maximum_version})
         message(WARNING "Qpid proton ${Proton_VERSION} is not a tested version and might not be compatible, ${maximum_version} is highest tested; build may not work")

--- a/src/qpid/broker/Selector.cpp
+++ b/src/qpid/broker/Selector.cpp
@@ -108,7 +108,7 @@ MessageSelectorEnv::MessageSelectorEnv(const Message& m) :
 
 const Value MessageSelectorEnv::specialValue(const string& id) const
 {
-    Value v;
+    Value v = Value();
     // TODO: Just use a simple if chain for now - improve this later
     if ( id=="delivery_mode" ) {
         v = msg.getEncoding().isPersistent() ? PERSISTENT : NON_PERSISTENT;
@@ -165,8 +165,6 @@ const Value MessageSelectorEnv::specialValue(const string& id) const
             returnedStrings.push_back(new string(jmsType));
             v = returnedStrings[returnedStrings.size()-1];
         }
-    } else {
-        v = Value();
     }
     return v;
 }

--- a/src/qpid/broker/Selector.cpp
+++ b/src/qpid/broker/Selector.cpp
@@ -108,7 +108,7 @@ MessageSelectorEnv::MessageSelectorEnv(const Message& m) :
 
 const Value MessageSelectorEnv::specialValue(const string& id) const
 {
-    Value v = Value();
+    Value v;
     // TODO: Just use a simple if chain for now - improve this later
     if ( id=="delivery_mode" ) {
         v = msg.getEncoding().isPersistent() ? PERSISTENT : NON_PERSISTENT;

--- a/src/qpid/broker/SelectorExpression.cpp
+++ b/src/qpid/broker/SelectorExpression.cpp
@@ -1036,7 +1036,7 @@ Expression* unaryArithExpression(Tokeniser& tokeniser)
 Expression* parseExactNumeric(const Token& token, bool negate)
 {
     int base = 0;
-    string s;
+    string s("");
     std::remove_copy(token.val.begin(), token.val.end(), std::back_inserter(s), '_');
     if (s[1]=='b' || s[1]=='B') {
         base = 2;

--- a/src/qpid/broker/SelectorToken.h
+++ b/src/qpid/broker/SelectorToken.h
@@ -70,7 +70,7 @@ struct Token {
     std::string::const_iterator tokenStart;
 
     Token() :
-        type()
+        type(T_EOS)
     {}
 
     Token(TokenType t, const std::string& v) :

--- a/src/qpid/broker/SelectorToken.h
+++ b/src/qpid/broker/SelectorToken.h
@@ -69,7 +69,8 @@ struct Token {
     std::string val;
     std::string::const_iterator tokenStart;
 
-    Token()
+    Token() :
+        type()
     {}
 
     Token(TokenType t, const std::string& v) :

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -213,7 +213,8 @@ add_executable (unit_test unit_test
                 ${actual_unit_tests} ${platform_test_additions})
 target_link_libraries (unit_test
                        ${qpid_test_boost_libs}
-                       qpidmessaging qpidtypes qpidbroker qpidclient qpidcommon)
+                       qpidmessaging qpidtypes qpidbroker qpidclient qpidcommon
+                       pthread)
 
 endif (BUILD_TESTING_UNITTESTS)
 


### PR DESCRIPTION
Do not merge.  For review purposes only.

This includes the sketchy initialization changes to make things compile on Fedora 26.  It now also includes the clang linking fix, eliminates the swig cmake warnings, and bumps the max tested proton version.