### PR TITLE
QPID-7926: [c++ broker] Windows build error "cannot convert from 'int…

### DIFF
--- a/src/qpid/log/Logger.cpp
+++ b/src/qpid/log/Logger.cpp
@@ -45,12 +45,12 @@ inline void Logger::enable_unlocked(Statement* s) {
 }
 
 namespace {
-sys::PODMutex loggerLock = QPID_MUTEX_INITIALIZER;
+sys::GlobalMutex loggerLock QPID_MUTEX_INITIALIZER;
 std::auto_ptr<Logger> logger;
 }
 
 Logger& Logger::instance() {
-    sys::PODMutex::ScopedLock l(loggerLock);
+    sys::GlobalMutex::ScopedLock l(loggerLock);
     if (!logger.get()) logger.reset(new Logger);
     return *logger;
 }

--- a/src/qpid/sys/posix/Mutex.h
+++ b/src/qpid/sys/posix/Mutex.h
@@ -75,32 +75,32 @@ protected:
 
 
 /**
- * PODMutex is a POD, can be static-initialized with
- * PODMutex m = QPID_MUTEX_INITIALIZER
+ * GlobalMutex is a POD and must be static-initialized as follows so:
+ * GlobalMutex m QPID_MUTEX_INITIALIZER;
  */
-struct PODMutex
+struct GlobalMutex
 {
-    typedef ::qpid::sys::ScopedLock<PODMutex> ScopedLock;
+    typedef ::qpid::sys::ScopedLock<GlobalMutex> ScopedLock;
 
     inline void lock();
     inline void unlock();
     inline bool trylock();
 
-    // Must be public to be a POD:
+    // Must be public to be a Global:
     pthread_mutex_t mutex;
 };
 
-#define QPID_MUTEX_INITIALIZER { PTHREAD_MUTEX_INITIALIZER }
+#define QPID_MUTEX_INITIALIZER = { PTHREAD_MUTEX_INITIALIZER }
 
-void PODMutex::lock() {
+void GlobalMutex::lock() {
     QPID_POSIX_ASSERT_THROW_IF(pthread_mutex_lock(&mutex));
 }
 
-void PODMutex::unlock() {
+void GlobalMutex::unlock() {
     QPID_POSIX_ASSERT_THROW_IF(pthread_mutex_unlock(&mutex));
 }
 
-bool PODMutex::trylock() {
+bool GlobalMutex::trylock() {
     return pthread_mutex_trylock(&mutex) == 0;
 }
 

--- a/src/qpid/sys/windows/Mutex.h
+++ b/src/qpid/sys/windows/Mutex.h
@@ -46,7 +46,7 @@ class Mutex : private boost::noncopyable {
 public:
     typedef ::qpid::sys::ScopedLock<Mutex> ScopedLock;
     typedef ::qpid::sys::ScopedUnlock<Mutex> ScopedUnlock;
-     
+
     inline Mutex();
     inline ~Mutex();
     inline void lock();  
@@ -85,34 +85,17 @@ protected:
 
 
 /**
- * PODMutex is a POD, can be static-initialized with
- * PODMutex m = QPID_MUTEX_INITIALIZER
+ * GlobalMutex must be declared like this for portabiliity:
+ * GlobalMutex m QPID_MUTEX_INITIALIZER;
+ *
+ * boost::recursive_mutex can be safely used as a global variable so QPID_MUTEX_INITIALIZER
+ * is empty.
  */
-struct PODMutex 
-{
-    typedef ::qpid::sys::ScopedLock<PODMutex> ScopedLock;
-
-    inline void lock();  
-    inline void unlock();
-    inline bool trylock();  
-
-    // Must be public to be a POD:
-    boost::recursive_mutex mutex;
+struct GlobalMutex : public boost::recursive_mutex {
+    typedef ::qpid::sys::ScopedLock<GlobalMutex> ScopedLock;
 };
 
-#define QPID_MUTEX_INITIALIZER 0
-
-void PODMutex::lock() {
-    mutex.lock();
-}
-
-void PODMutex::unlock() {
-    mutex.unlock();
-}
-
-bool PODMutex::trylock() {
-    return mutex.try_lock();
-}
+#define QPID_MUTEX_INITIALIZER
 
 Mutex::Mutex() {
 }


### PR DESCRIPTION
…' to 'qpid::sys::PODMutex'"

Renamed PODMutex as GlobalMutex. The important point is that it can be used as a
global variable. In POSIX we use a POD class and static initializer to acomplish
this, but on windows we use boost::recursive_mutex, which is documented as being
safe for use as a global variable.

Modified the QPID_MUTEX_INITIALIZER macro to be empty on windows and '= { 0 }'
on POSIX.

This closes #11