### PR TITLE
QPID-5285 [AMQP 1.0] timestamped messages not supported

### DIFF
--- a/src/qpid/broker/amqp/Incoming.cpp
+++ b/src/qpid/broker/amqp/Incoming.cpp
@@ -28,6 +28,7 @@
 #include "qpid/broker/Message.h"
 #include "qpid/broker/Broker.h"
 #include "qpid/log/Statement.h"
+#include "qpid/sys/Time.h"
 
 namespace qpid {
 namespace broker {
@@ -146,6 +147,8 @@ void DecodingIncoming::readable(pn_delivery_t* delivery)
 void DecodingIncoming::deliver(boost::intrusive_ptr<qpid::broker::amqp::Message> received, pn_delivery_t* delivery)
 {
     qpid::broker::Message message(received, received);
+    qpid::sys::Duration d(qpid::sys::AbsTime::epoch(), qpid::sys::AbsTime::now());
+    message.addAnnotation("x-opt-ingress-timestamp", (int64_t)d);	
     userid.verify(message.getUserId());
     received->begin();
     handle(message, session.getTransaction(delivery));

--- a/src/qpid/broker/amqp/Incoming.cpp
+++ b/src/qpid/broker/amqp/Incoming.cpp
@@ -109,7 +109,11 @@ namespace {
 }
 
 DecodingIncoming::DecodingIncoming(pn_link_t* link, Broker& broker, Session& parent, const std::string& source, const std::string& target, const std::string& name)
-    : Incoming(link, broker, parent, source, target, name), sessionPtr(parent.shared_from_this()) {}
+    : Incoming(link, broker, parent, source, target, name), sessionPtr(parent.shared_from_this())
+{
+    isTimestamping = broker.isTimestamping();
+}
+
 DecodingIncoming::~DecodingIncoming() {}
 
 void DecodingIncoming::readable(pn_delivery_t* delivery)
@@ -147,8 +151,10 @@ void DecodingIncoming::readable(pn_delivery_t* delivery)
 void DecodingIncoming::deliver(boost::intrusive_ptr<qpid::broker::amqp::Message> received, pn_delivery_t* delivery)
 {
     qpid::broker::Message message(received, received);
+    if (isTimestamping) {
     qpid::sys::Duration d(qpid::sys::AbsTime::epoch(), qpid::sys::AbsTime::now());
-    message.addAnnotation("x-opt-ingress-timestamp", (int64_t)d);	
+    message.addAnnotation("x-opt-ingress-timestamp",(int64_t)d);
+    }	
     userid.verify(message.getUserId());
     received->begin();
     handle(message, session.getTransaction(delivery));

--- a/src/qpid/broker/amqp/Incoming.cpp
+++ b/src/qpid/broker/amqp/Incoming.cpp
@@ -109,10 +109,7 @@ namespace {
 }
 
 DecodingIncoming::DecodingIncoming(pn_link_t* link, Broker& broker, Session& parent, const std::string& source, const std::string& target, const std::string& name)
-    : Incoming(link, broker, parent, source, target, name), sessionPtr(parent.shared_from_this())
-{
-    isTimestamping = broker.isTimestamping();
-}
+    : Incoming(link, broker, parent, source, target, name), sessionPtr(parent.shared_from_this()), isTimestamping(broker.isTimestamping()) {}
 
 DecodingIncoming::~DecodingIncoming() {}
 

--- a/src/qpid/broker/amqp/Incoming.cpp
+++ b/src/qpid/broker/amqp/Incoming.cpp
@@ -152,8 +152,8 @@ void DecodingIncoming::deliver(boost::intrusive_ptr<qpid::broker::amqp::Message>
 {
     qpid::broker::Message message(received, received);
     if (isTimestamping) {
-    qpid::sys::Duration d(qpid::sys::AbsTime::epoch(), qpid::sys::AbsTime::now());
-    message.addAnnotation("x-opt-ingress-timestamp",(int64_t)d);
+        qpid::sys::Duration d(qpid::sys::AbsTime::epoch(), qpid::sys::AbsTime::now());
+        message.addAnnotation("x-opt-ingress-timestamp",(int64_t)d);
     }	
     userid.verify(message.getUserId());
     received->begin();

--- a/src/qpid/broker/amqp/Incoming.h
+++ b/src/qpid/broker/amqp/Incoming.h
@@ -80,7 +80,7 @@ class DecodingIncoming : public Incoming
   private:
     boost::shared_ptr<Session> sessionPtr;
     boost::intrusive_ptr<Message> partial;
-    bool isTimestamping;
+    const bool isTimestamping;
 };
 
 }}} // namespace qpid::broker::amqp

--- a/src/qpid/broker/amqp/Incoming.h
+++ b/src/qpid/broker/amqp/Incoming.h
@@ -80,6 +80,7 @@ class DecodingIncoming : public Incoming
   private:
     boost::shared_ptr<Session> sessionPtr;
     boost::intrusive_ptr<Message> partial;
+    bool isTimestamping;
 };
 
 }}} // namespace qpid::broker::amqp


### PR DESCRIPTION
Added a timestamp marking the actual arrival time at the broker.
Change affects the DecodingIncoming:deliver method.
Property "x-opt-ingress-timestamp" has been added to the received qpid::broker::Message to be set as nanoseconds from epoch.