### PR TITLE
QPID-8319: clear persistent connection context on autodeleted msgs

### DIFF
--- a/src/qpid/broker/Queue.cpp
+++ b/src/qpid/broker/Queue.cpp
@@ -792,7 +792,10 @@ uint32_t Queue::remove(const uint32_t maxCount, MessagePredicate p, MessageFunct
         }
     }
     for (std::deque<Message>::iterator i = removed.begin(); i != removed.end(); ++i) {
-        if (f) f(*i);//ERROR? need to clear old persistent context?
+        if (f) {
+            (*i).getSharedState().setPublisher(0);  // clear scopedManagementContext
+            f(*i);//ERROR? need to clear other old persistent context?
+        }
         if (i->isPersistent()) dequeueFromStore(i->getPersistentContext());//do this outside of lock and after any re-routing
     }
     return removed.size();


### PR DESCRIPTION
In the event that
 1) the message is a QMF request
 2) it is in an autoDelete queue
 3) the queue has an alternate exchange 'qmf.default.direct'
 4) the original connection is lost

then the router may segfault or otherwise misbehave since the message's
connection context is now invalid.

This patch clears the connection context for *all* autodeleted messages
and as such may be too aggressive clearing the context.  Review Needed 

This patch does not include a self test.