### PR TITLE
fixed order within member initializer list

### DIFF
--- a/examples/messaging/spout.cpp
+++ b/examples/messaging/spout.cpp
@@ -58,8 +58,8 @@ struct Options : OptionParser
         : OptionParser("Usage: spout [OPTIONS] ADDRESS", "Send messages to the specified address"),
           url("127.0.0.1"),
           timeout(0),
-          count(1),
           durable(false),
+          count(1),
           print(false)
     {
         add("broker,b", url, "url of broker to connect to");


### PR DESCRIPTION
This pull request addresses the following compiler warning:

```
spout.cpp: In constructor ‘Options::Options()’:
spout.cpp:48:9: warning: ‘Options::count’ will be initialized after [-Wreorder]
     int count;
         ^~~~~
spout.cpp:47:10: warning:   ‘bool Options::durable’ [-Wreorder]
     bool durable;
          ^~~~~~~
spout.cpp:57:5: warning:   when initialized here [-Wreorder]
     Options()
     ^~~~~~~
```