### PR TITLE
NO-JIRA: Fix various typos and spelling errors

### DIFF
--- a/docs/book/src/messaging-api/Qpid-Messaging-API.xml
+++ b/docs/book/src/messaging-api/Qpid-Messaging-API.xml
@@ -219,7 +219,7 @@ under the License.
 	  <callout id="callout-python-acknowledge" arearefs="hello-python-acknowledge">
 	    <para>Acknowledges receipt of all fetched messages on
 	    the session. This informs the broker that the messages were
-	    transfered and processed by the client successfully.</para>
+	    transferred and processed by the client successfully.</para>
 	  </callout>
 	  <callout id="callout-python-close" arearefs="hello-python-close">
 	    <para>Closes the connection, all sessions managed by the connection, and all senders and receivers managed by each session.</para>
@@ -311,7 +311,7 @@ under the License.
 	  <callout id="callout-csharp-acknowledge" arearefs="hello-csharp-acknowledge">
 	    <para>Acknowledges receipt of all fetched messages on the
 	    session. This informs the broker that the messages were
-	    transfered and processed by the client successfully.</para>
+	    transferred and processed by the client successfully.</para>
 	  </callout>
 	  <callout id="callout-csharp-close" arearefs="hello-csharp-close">
 	    <para>Closes the connection, all sessions managed by the connection, and all senders and receivers managed by each session.</para>
@@ -2483,9 +2483,9 @@ spout - -content "$(cat rdu.xml | sed -e 's/70/45/')" xml/weather
       </para>
       <para>
         When sending to a queue, the queue's name is set as the
-        routing key and the message is transfered to the default (or
+        routing key and the message is transferred to the default (or
         nameless) exchange. When sending to an exchange, the message
-        is transfered to that exchange and the routing key is set to
+        is transferred to that exchange and the routing key is set to
         the message subject if one is specified. A default subject may
         be specified in the target address. The subject may also be
         set on each message individually to override the default if

--- a/docs/man/qpid-send.1
+++ b/docs/man/qpid-send.1
@@ -117,7 +117,7 @@ message header 'KEY' to hold the group
 identifier
 .TP
 \fB\-\-group\-prefix\fR STRING (GROUP\-)
-Generate group identifers with 'STRING'
+Generate group identifiers with 'STRING'
 prefix (if group\-key specified)
 .TP
 \fB\-\-group\-size\fR N (10)

--- a/docs/man/qpidd.1
+++ b/docs/man/qpidd.1
@@ -179,7 +179,7 @@ Override the federation tag
 .TP
 \fB\-\-session\-max\-unacked\fR DELIVERIES (5000)
 Maximum number of un\-acknowledged
-outoing messages per sesssion
+outoing messages per session
 .SS "Logging options:"
 .TP
 \fB\-t\fR [ \fB\-\-trace\fR ]

--- a/management/python/bin/qpid-send
+++ b/management/python/bin/qpid-send
@@ -70,7 +70,7 @@ op.add_option("--flow-control", default=0, type="int", help="Do end to end flow 
 op.add_option("--sequence", type="str", default="yes", help="Add a sequence number messages property (required for duplicate/lost message detection)")
 op.add_option("--timestamp", type="str", default="yes", help="Add a time stamp messages property (required for latency measurement)")
 op.add_option("--group-key", type="str", help="Generate groups of messages using message header 'KEY' to hold the group identifier")
-op.add_option("--group-prefix", default="GROUP-", type="str", help="Generate group identifers with 'STRING' prefix (if group-key specified)")
+op.add_option("--group-prefix", default="GROUP-", type="str", help="Generate group identifiers with 'STRING' prefix (if group-key specified)")
 op.add_option("--group-size", default=10, type="int", help="Number of messages per a group (if group-key specified)")
 op.add_option("--group-randomize-size", default=False, action="store_true", help="Randomize the number of messages per group to [1...group-size] (if group-key specified)")
 op.add_option("--group-interleave", default=1, type="int", help="Simultaineously interleave messages from N different groups (if group-key specified)")

--- a/management/python/bin/qpid-store-resize
+++ b/management/python/bin/qpid-store-resize
@@ -105,7 +105,7 @@ class Resize(object):
     
     def _create_new_files(self):
         """Create new journal files"""
-        # Assemble records to be transfered
+        # Assemble records to be transferred
         master_record_list = {}
         txn_record_list = self._jrnl_reader.txn_obj_list()
         if self._opts.vflag and self._jrnl_reader.emap().size() > 0:

--- a/src/qpid/broker/Broker.cpp
+++ b/src/qpid/broker/Broker.cpp
@@ -203,7 +203,7 @@ BrokerOptions::BrokerOptions(const std::string& name) :
         ("dtx-max-timeout", optValue(dtxMaxTimeout, "SECONDS"), "Maximum allowed timeout for DTX transaction. A value of zero disables maximum timeout limit checks and allows arbitrarily large timeout settings.")
         ("max-negotiate-time", optValue(maxNegotiateTime, "MILLISECONDS"), "Maximum time a connection can take to send the initial protocol negotiation")
         ("federation-tag", optValue(fedTag, "NAME"), "Override the federation tag")
-        ("session-max-unacked", optValue(sessionMaxUnacked, "DELIVERIES"), "Maximum number of un-acknowledged outoing messages per sesssion")
+        ("session-max-unacked", optValue(sessionMaxUnacked, "DELIVERIES"), "Maximum number of un-acknowledged outoing messages per session")
         ;
 }
 
@@ -1238,7 +1238,7 @@ Manageable::status_t Broker::queueRedirect(const std::string& srcQueue,
             std::map<acl::Property, std::string> params;
             params.insert(make_pair(acl::PROP_QUEUENAME, tgtQ->getName()));
             if (!acl->authorise((context)?context->getUserId():"", acl::ACT_REDIRECT, acl::OBJ_QUEUE, srcQ->getName(), &params))
-                throw framing::UnauthorizedAccessException(QPID_MSG("ACL denied redirect request from " << ((context)?context->getUserId():"(uknown)")));
+                throw framing::UnauthorizedAccessException(QPID_MSG("ACL denied redirect request from " << ((context)?context->getUserId():"(unknown)")));
         }
 
         // Start the backup overflow partnership
@@ -1276,7 +1276,7 @@ Manageable::status_t Broker::queueRedirect(const std::string& srcQueue,
             std::map<acl::Property, std::string> params;
             params.insert(make_pair(acl::PROP_QUEUENAME, tgtQ->getName()));
             if (!acl->authorise((context)?context->getUserId():"", acl::ACT_REDIRECT, acl::OBJ_QUEUE, srcQ->getName(), &params))
-                throw framing::UnauthorizedAccessException(QPID_MSG("ACL denied redirect request from " << ((context)?context->getUserId():"(uknown)")));
+                throw framing::UnauthorizedAccessException(QPID_MSG("ACL denied redirect request from " << ((context)?context->getUserId():"(unknown)")));
         }
 
         queueRedirectDestroy(srcQ, tgtQ, true);
@@ -1390,7 +1390,7 @@ int32_t Broker::queueMoveMessages(
         std::map<acl::Property, std::string> params;
         params.insert(make_pair(acl::PROP_QUEUENAME, dest_queue->getName()));
         if (!acl->authorise((context)?context->getUserId():"", acl::ACT_MOVE, acl::OBJ_QUEUE, src_queue->getName(), &params))
-            throw framing::UnauthorizedAccessException(QPID_MSG("ACL denied move request from " << ((context)?context->getUserId():"(uknown)")));
+            throw framing::UnauthorizedAccessException(QPID_MSG("ACL denied move request from " << ((context)?context->getUserId():"(unknown)")));
     }
 
     return (int32_t) src_queue->move(dest_queue, qty, &filter);

--- a/src/qpid/broker/management-schema.xml
+++ b/src/qpid/broker/management-schema.xml
@@ -403,7 +403,7 @@
     <property name="source"         type="sstr"     access="RC"/>
     <property name="target"         type="sstr"     access="RC"/>
     <property name="domain"         type="sstr"     access="RC"/>
-    <statistic name="transfers"     type="count64"  unit="message" desc="Messages transfered"/>
+    <statistic name="transfers"     type="count64"  unit="message" desc="Messages transferred"/>
   </class>
   <!--
   ===============================================================
@@ -417,7 +417,7 @@
     <property name="source"         type="sstr"     access="RC"/>
     <property name="target"         type="sstr"     access="RC"/>
     <property name="domain"         type="sstr"     access="RC"/>
-    <statistic name="transfers"     type="count64"  unit="message" desc="Messages transfered"/>
+    <statistic name="transfers"     type="count64"  unit="message" desc="Messages transferred"/>
   </class>
   <!--
   ===============================================================

--- a/src/tests/legacystore/persistence.py
+++ b/src/tests/legacystore/persistence.py
@@ -106,7 +106,7 @@ class PersistenceTest(TestBase010):
         session.message_transfer(destination="amq.topic",
                                  message=self.createMessage(routing_key="abc", correlation_id="Msg0003", body="AB_Message2"))
 
-#        #check LVQ exists and has exepected messages:
+#        #check LVQ exists and has expected messages:
 #        session.queue_declare(queue="lvq-test", durable=True, passive=True)
 #        session.message_subscribe(destination="lvq", queue="lvq-test")
 #        lvq = session.incoming("lvq")

--- a/src/tests/qpid-client-test.cpp
+++ b/src/tests/qpid-client-test.cpp
@@ -124,7 +124,7 @@ int main(int argc, char** argv)
         SubscriptionManager subs(session);
         Message msgIn = subs.get("MyQueue");
         if (msgIn.getData() == msgOut.getData())
-            if (opts.verbose) std::cout << "Received the exepected message." << std::endl;
+            if (opts.verbose) std::cout << "Received the expected message." << std::endl;
 
         //close the session & connection
 	session.close();

--- a/src/tests/qpid-perftest.cpp
+++ b/src/tests/qpid-perftest.cpp
@@ -197,12 +197,12 @@ struct Opts : public TestOptions {
         transfers=(totalPubs*count) + (totalSubs*subQuota);
         if (tx) {
             if (txPub) {
-                cerr << "WARNING: Using overriden tx value for publishers: " << txPub << std::endl;
+                cerr << "WARNING: Using overridden tx value for publishers: " << txPub << std::endl;
             } else {
                 txPub = tx;
             }
             if (txSub) {
-                cerr << "WARNING: Using overriden tx value for subscribers: " << txSub << std::endl;
+                cerr << "WARNING: Using overridden tx value for subscribers: " << txSub << std::endl;
             } else {
                 txSub = tx;
             }

--- a/src/tests/qpid-send.cpp
+++ b/src/tests/qpid-send.cpp
@@ -153,7 +153,7 @@ struct Options : public qpid::Options
             ("sequence", qpid::optValue(sequence, "yes|no"), "Add a sequence number messages property (required for duplicate/lost message detection)")
             ("timestamp", qpid::optValue(timestamp, "yes|no"), "Add a time stamp messages property (required for latency measurement)")
             ("group-key", qpid::optValue(groupKey, "KEY"), "Generate groups of messages using message header 'KEY' to hold the group identifier")
-            ("group-prefix", qpid::optValue(groupPrefix, "STRING"), "Generate group identifers with 'STRING' prefix (if group-key specified)")
+            ("group-prefix", qpid::optValue(groupPrefix, "STRING"), "Generate group identifiers with 'STRING' prefix (if group-key specified)")
             ("group-size", qpid::optValue(groupSize, "N"), "Number of messages per a group (if group-key specified)")
             ("group-randomize-size", qpid::optValue(groupRandSize), "Randomize the number of messages per group to [1...group-size] (if group-key specified)")
             ("group-interleave", qpid::optValue(groupInterleave, "N"), "Simultaineously interleave messages from N different groups (if group-key specified)")

--- a/src/tests/qpid-txtest.cpp
+++ b/src/tests/qpid-txtest.cpp
@@ -231,7 +231,7 @@ struct Controller : public Client
             StringSet::iterator next = i + 1;
             if (next == queues.end()) next = queues.begin();
 
-            if (!opts.quiet) std::cout << "Transfering from " << *i << " to " << *next << std::endl;
+            if (!opts.quiet) std::cout << "Transferring from " << *i << " to " << *next << std::endl;
             agents.push_back(new Transfer(*i, *next));
             agents.back().thread = Thread(agents.back());
         }

--- a/src/tests/qpid-txtest2.cpp
+++ b/src/tests/qpid-txtest2.cpp
@@ -281,7 +281,7 @@ struct Controller : public Client
             StringSet::iterator next = i + 1;
             if (next == queues.end()) next = queues.begin();
 
-            if (!opts.quiet) std::cout << "Transfering from " << *i << " to " << *next << std::endl;
+            if (!opts.quiet) std::cout << "Transferring from " << *i << " to " << *next << std::endl;
             agents.push_back(new Transfer(*i, *next, opts));
             agents.back().thread = Thread(agents.back());
         }

--- a/src/tests/txshift.cpp
+++ b/src/tests/txshift.cpp
@@ -56,13 +56,13 @@ struct Transfer : MessageListener
     std::string source;
     std::string destination;
     uint expected;
-    uint transfered;
+    uint transferred;
     SubscriptionSettings controlSettings;
     Subscription controlSubscription;
     SubscriptionSettings sourceSettings;
     Subscription sourceSubscription;
 
-    Transfer(const std::string control_) : control(control_), expected(0), transfered(0) {}
+    Transfer(const std::string control_) : control(control_), expected(0), transferred(0) {}
 
     void subscribeToSource(SubscriptionManager manager)
     {
@@ -93,11 +93,11 @@ struct Transfer : MessageListener
 
     void receivedFromSource(Message& message)
     {
-        QPID_LOG(debug, "transfering  " << (transfered+1) << " of " << expected);
+        QPID_LOG(debug, "transfering  " << (transferred+1) << " of " << expected);
         message.getDeliveryProperties().setRoutingKey(destination);
         async(sourceSubscription.getSession()).messageTransfer(arg::content=message);
-        if (++transfered == expected) {
-            QPID_LOG(info, "completed job: " << transfered << " messages shifted from " <<
+        if (++transferred == expected) {
+            QPID_LOG(info, "completed job: " << transferred << " messages shifted from " <<
                      source << " to " << destination);
             sourceSubscription.accept(sourceSubscription.getUnaccepted());
             sourceSubscription.getSession().txCommit();
@@ -113,7 +113,7 @@ struct Transfer : MessageListener
             source = message.getHeaders().getAsString("src");
             destination = message.getHeaders().getAsString("dest");
             expected = message.getHeaders().getAsInt("count");
-            transfered = 0;
+            transferred = 0;
             QPID_LOG(info, "received transfer request: " << expected << " messages to be shifted from " <<
                      source << " to " << destination);
             subscribeToSource(controlSubscription.getSubscriptionManager());


### PR DESCRIPTION
There are spelling errors in the code, this PR fixes some of them:

    exepected -> expected
    identifers -> identifiers
    overriden -> overridden
    sesssion -> session
    transfered -> transferred
    transfering -> transferring
    uknown -> unknown
