### PR TITLE
QPID-8610: add GitHub Actions workflow to build project and run ctest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [ push, pull_request ]
+on: [ push, pull_request, workflow_dispatch ]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,6 +161,12 @@ jobs:
           cmake --install "${{env.BuildDir}}" --config ${{env.BuildType}}
         shell: pwsh
 
+      - name: Add qpidd to path for tests
+        if: runner.os == 'Windows'
+        run: |
+          Add-Content ${env:GITHUB_PATH} "${{env.BuildDir}}/src"
+        shell: pwsh
+
       - id: ctest
         name: ctest
         working-directory: ${{env.BuildDir}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
             libboost-dev libboost-program-options-dev libboost-system-dev libboost-test-dev \
             libxqilla-dev libxerces-c-dev \
             libibverbs-dev librdmacm-dev \
-            libdb-dev \
+            libdb++-dev \
             libqpid-proton11-dev libqpid-proton-core10 libqpid-proton-proactor1 \
             swig3.0 python-dev ruby2.6 ruby2.6-dev \
             uuid-dev libnss3-dev libnss3-tools libsasl2-dev sasl2-bin \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
           
           # work around assumptions in our build scripts about boost libs layout
           Copy-Item -Path C:/vcpkg/installed/x64-windows/debug/bin/* -Include *.dll -Destination C:/vcpkg/installed/x64-windows/debug/lib
-          Get-Item C:/vcpkg/installed/x64-windows/debug/lib/*.dll | Rename-Item -NewName { $_.Name -replace '-vc14*-gd-x64-1_81.dll','-vc140-mt-gd.dll' }
+          Get-Item C:/vcpkg/installed/x64-windows/debug/lib/*.dll | Rename-Item -NewName { $_.Name -replace '-vc14.-gd-x64-1_81.dll','-vc140-mt-gd.dll' }
           # display results of this hard work
           ls C:/vcpkg/installed/x64-windows/debug/bin/
           ls C:/vcpkg/installed/x64-windows/debug/lib/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
           
           # work around assumptions in our build scripts about boost libs layout
           Copy-Item -Path C:/vcpkg/installed/x64-windows/debug/bin/* -Include *.dll -Destination C:/vcpkg/installed/x64-windows/debug/lib
-          Get-Item C:/vcpkg/installed/x64-windows/debug/lib/*.dll | Rename-Item -NewName { $_.Name -replace '-vc14.-gd-x64-1_81.dll','-vc140-mt-gd.dll' }
+          Get-Item C:/vcpkg/installed/x64-windows/debug/lib/*.dll | Rename-Item -NewName { $_.Name -replace '-vc14.-mt-gd-x64-1_81.dll','-vc140-mt-gd.dll' }
           # display results of this hard work
           ls C:/vcpkg/installed/x64-windows/debug/bin/
           ls C:/vcpkg/installed/x64-windows/debug/lib/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,13 +106,12 @@ jobs:
           vcpkg integrate install
 
           # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#add-a-system-path-add-path
-          echo $PATH >> $GITHUB_PATH
+          echo "${HOME}/scoop/shims" | Out-File -FilePath ${env:GITHUB_PATH} -Encoding utf8 -Append
         shell: pwsh
 
       # https://devblogs.microsoft.com/scripting/powertip-line-continuation-in-powershell/
       - name: cmake configure
         run: |
-          set cache (gcm ~\scoop\shims\sccache).Path
           cmake -S "${{github.workspace}}" -B "${{env.BuildDir}}" -G Ninja `
             -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" `
             -DCMAKE_C_COMPILER_LAUNCHER="sccache" -DCMAKE_CXX_COMPILER_LAUNCHER="sccache" `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,10 +101,12 @@ jobs:
           Set-ExecutionPolicy RemoteSigned -Scope CurrentUser # Optional: Needed to run a remote script the first time
           iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
           scoop install ninja sccache
-          ~\scoop\apps\sccache\current\sccache.exe --help
-          sccache.exe --help
+
           vcpkg install boost-program-options boost-system boost-test boost-date-time boost-thread boost-chrono boost-format boost-ptr-container boost-assign boost-parameter boost-foreach boost-utility
           vcpkg integrate install
+
+          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#add-a-system-path-add-path
+          echo $PATH >> $GITHUB_PATH
         shell: pwsh
 
       # https://devblogs.microsoft.com/scripting/powertip-line-continuation-in-powershell/
@@ -113,7 +115,7 @@ jobs:
           set cache (gcm ~\scoop\shims\sccache).Path
           cmake -S "${{github.workspace}}" -B "${{env.BuildDir}}" -G Ninja `
             -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" `
-            -DCMAKE_C_COMPILER_LAUNCHER="${cache}" -DCMAKE_CXX_COMPILER_LAUNCHER="${cache}" `
+            -DCMAKE_C_COMPILER_LAUNCHER="sccache" -DCMAKE_CXX_COMPILER_LAUNCHER="sccache" `
             "-DCMAKE_BUILD_TYPE=${{env.BuildType}}" `
             "-DCMAKE_INSTALL_PREFIX=${{env.InstallPrefix}}" `
             ${{matrix.cmake_extra}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,11 @@ jobs:
 
           # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#add-a-system-path-add-path
           Add-Content ${env:GITHUB_PATH} "${HOME}/scoop/shims"
+          
+          ls C:/vcpkg/installed/x64-windows/
+          ls C:/vcpkg/installed/x64-windows/debug/
+          ls C:/vcpkg/installed/x64-windows/debug/lib/
+          ls C:/vcpkg/installed/x64-windows/debug/lib/boost_date_time-vc140-mt-gd.dll
         shell: pwsh
 
       # Windows build should ideally use something like '-G "Visual Studio 16 2019" -A x64',

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
       # https://devblogs.microsoft.com/scripting/powertip-line-continuation-in-powershell/
       - name: cmake configure
         run: |
-          set cache (gcm sccache).Path
+          set cache (gcm ~\scoop\shims\sccache).Path
           cmake -S "${{github.workspace}}" -B "${{env.BuildDir}}" -G Ninja `
             -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" `
             -DCMAKE_C_COMPILER_LAUNCHER="${cache}" -DCMAKE_CXX_COMPILER_LAUNCHER="${cache}" `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
         buildType: [ RelWithDebInfo ]
         include:
           - os: windows-latest
-            cmake_extra: '-DBUILD_BINDING_DOTNET=OFF -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake'
+            cmake_extra: '-DQPID_LINK_BOOST_DYNAMIC=OFF -DBUILD_BINDING_DOTNET=OFF -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake'
     env:
       BuildType: ${{matrix.buildType}}
       BuildDir: ${{github.workspace}}/BLD

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
           Add-Content ${env:GITHUB_PATH} "${HOME}/scoop/shims"
           
           # work around assumptions in our build scripts about boost layout
-          Copy-Item -Path C:/vcpkg/installed/x64-windows/debug/bin/* -Include "*.dll" -Destination C:/vcpkg/installed/x64-windows/debug/lib/
+          Copy-Item -Path C:/vcpkg/installed/x64-windows/debug/bin/* -Include *.dll -Destination C:/vcpkg/installed/x64-windows/debug/lib/
           
           ls C:/vcpkg/installed/x64-windows/debug/bin/
           ls C:/vcpkg/installed/x64-windows/debug/lib/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,11 +127,8 @@ jobs:
           # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#add-a-system-path-add-path
           Add-Content ${env:GITHUB_PATH} "${HOME}/scoop/shims"
           
-          ls C:/vcpkg/installed/x64-windows/
-          ls C:/vcpkg/installed/x64-windows/debug/
-          ls C:/vcpkg/installed/x64-windows/debug/lib/
-          ls C:/vcpkg/installed/x64-windows/debug/bin/
-          ls C:/vcpkg/installed/x64-windows/debug/lib/boost_date_time-vc140-mt-gd.dll
+          # work around assumptions in our build scripts about boost layout
+          Copy-Item -Path C:/vcpkg/installed/x64-windows/debug/bin/ -include "*.dll" -Destination C:/vcpkg/installed/x64-windows/debug/lib/
         shell: pwsh
 
       # Windows build should ideally use something like '-G "Visual Studio 16 2019" -A x64',

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
         if: runner.os == 'Windows'
         with:
           path: ~\scoop
-          key: ${{ runner.os }}-scoop-${{ env.OS_VER }}-${{ github.sha }}
+          key: ${{ runner.os }}-scoop-${{ env.OS_VER }}-${{ hashFiles('.github/workflows/build.yml') }}
           restore-keys: |
             ${{ runner.os }}-scoop-${{ env.OS_VER }}-
             ${{ runner.os }}-scoop-
@@ -72,7 +72,7 @@ jobs:
         if: runner.os == 'Windows'
         with:
           path: C:\vcpkg\downloads
-          key: ${{ runner.os }}-vcpkg-download-${{ env.OS_VER }}-${{ github.sha }}
+          key: ${{ runner.os }}-vcpkg-download-${{ env.OS_VER }}-${{ hashFiles('.github/workflows/build.yml') }}
           restore-keys: |
             ${{ runner.os }}-vcpkg-download-${{ env.OS_VER }}-
             ${{ runner.os }}-vcpkg-download-
@@ -81,7 +81,7 @@ jobs:
         if: runner.os == 'Windows'
         with:
           path: C:\vcpkg\installed
-          key: ${{ runner.os }}-vcpkg-installed-${{ matrix.os }}-${{ github.sha }}
+          key: ${{ runner.os }}-vcpkg-installed-${{ matrix.os }}-${{ hashFiles('.github/workflows/build.yml') }}
           restore-keys: |
             ${{ runner.os }}-vcpkg-installed-${{ matrix.os }}-
             ${{ runner.os }}-vcpkg-installed-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,12 +48,16 @@ jobs:
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |
+          # ubuntu packages (https://packages.ubuntu.com/source/focal/qpid-proton) don't carry ProtonConfig.cmake
+          # the `testing` ppa is less likely to be out-of-date
+          sudo add-apt-repository ppa:qpid/testing && sudo apt-get update
+
           sudo apt-get -yq --no-install-suggests --no-install-recommends install \
             cmake ninja-build \
             libboost-dev libboost-program-options-dev libboost-system-dev libboost-test-dev \
             libxqilla-dev libxerces-c-dev \
             libibverbs-dev librdmacm-dev \
-            libqpid-proton11-dev libqpid-proton-cpp12-dev \
+            libqpid-proton11-dev \
             uuid-dev libnss3-dev libnss3-tools libsasl2-dev sasl2-bin swig3.0 python-dev valgrind ruby
           
           sccache_version=v0.4.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
         include:
           - os: ubuntu-20.04
             # QPID-8606: we don't support swig 4.0, it produces runtime errors when used
-            cmake_extra: '-DSWIG_EXECUTABLE=/usr/bin/swig3.0'
+            cmake_extra: '-DSWIG_EXECUTABLE="/usr/bin/swig3.0"'
           - os: windows-latest
             cmake_extra: '-DBUILD_BINDING_DOTNET=OFF -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake'
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,12 +161,6 @@ jobs:
           cmake --install "${{env.BuildDir}}" --config ${{env.BuildType}}
         shell: pwsh
 
-      - name: Add qpidd to path for tests
-        if: runner.os == 'Windows'
-        run: |
-          Add-Content ${env:GITHUB_PATH} "${{env.BuildDir}}/src"
-        shell: pwsh
-
       - id: ctest
         name: ctest
         working-directory: ${{env.BuildDir}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,9 +129,6 @@ jobs:
           
           # work around assumptions in our build scripts about boost layout
           Copy-Item -Path C:/vcpkg/installed/x64-windows/debug/bin/* -Include "*.dll" -Destination C:/vcpkg/installed/x64-windows/debug/lib/
-          
-          ls C:/vcpkg/installed/x64-windows/debug/bin/
-          ls C:/vcpkg/installed/x64-windows/debug/lib/
         shell: pwsh
 
       # Windows build should ideally use something like '-G "Visual Studio 16 2019" -A x64',

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,13 +54,19 @@ jobs:
           # the `testing` ppa is less likely to be out-of-date
           sudo add-apt-repository ppa:qpid/testing && sudo apt-get update
 
+          # https://github.com/swig/swig/issues/1689
+          # swig3.0 in focal does not work well with ruby2.7
+          sudo apt-add-repository ppa:brightbox/ruby-ng && sudo apt-get update
+
           sudo apt-get -yq --no-install-suggests --no-install-recommends install \
             cmake ninja-build \
             libboost-dev libboost-program-options-dev libboost-system-dev libboost-test-dev \
             libxqilla-dev libxerces-c-dev \
             libibverbs-dev librdmacm-dev \
             libqpid-proton11-dev libqpid-proton-core10 libqpid-proton-proactor1 \
-            uuid-dev libnss3-dev libnss3-tools libsasl2-dev sasl2-bin swig3.0 python-dev valgrind ruby
+            swig3.0 python-dev ruby2.6-dev \
+            uuid-dev libnss3-dev libnss3-tools libsasl2-dev sasl2-bin \
+            valgrind 
 
           sccache_version=v0.4.1
           wget -q https://github.com/mozilla/sccache/releases/download/${sccache_version}/sccache-${sccache_version}-x86_64-unknown-linux-musl.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,11 +48,17 @@ jobs:
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get -yq --no-install-suggests --no-install-recommends install cmake ninja-build libboost-dev libboost-program-options-dev libboost-system-dev libboost-test-dev uuid-dev libnss3-dev libnss3-tools libsasl2-dev sasl2-bin swig3.0 python-dev valgrind ruby
+          sudo apt-get -yq --no-install-suggests --no-install-recommends install \
+            cmake ninja-build \
+            libboost-dev libboost-program-options-dev libboost-system-dev libboost-test-dev \
+            libxqilla-dev libxerces-c-dev \
+            libqpid-proton11-dev libqpid-proton-cpp12-dev \
+            uuid-dev libnss3-dev libnss3-tools libsasl2-dev sasl2-bin swig3.0 python-dev valgrind ruby
           wget -q https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz
           tar -xf sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz sccache-v0.3.0-x86_64-unknown-linux-musl/sccache
           sudo mv sccache-v0.3.0-x86_64-unknown-linux-musl/sccache /usr/bin/sccache
           sudo chmod +x /usr/bin/sccache
+        shell: bash
 
       - name: Cache scoop (on Windows)
         uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
           Add-Content ${env:GITHUB_PATH} "${HOME}/scoop/shims"
           
           # work around assumptions in our build scripts about boost layout
-          Copy-Item -Path C:/vcpkg/installed/x64-windows/debug/bin/ -include "*.dll" -Destination C:/vcpkg/installed/x64-windows/debug/lib/
+          Copy-Item -Path C:/vcpkg/installed/x64-windows/debug/bin/ -Include "*.dll" -Destination C:/vcpkg/installed/x64-windows/debug/lib/
         shell: pwsh
 
       # Windows build should ideally use something like '-G "Visual Studio 16 2019" -A x64',

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
             libboost-dev libboost-program-options-dev libboost-system-dev libboost-test-dev \
             libxqilla-dev libxerces-c-dev \
             libibverbs-dev librdmacm-dev \
-            libqpid-proton-core10-dev libqpid-proton11-dev \
+            libqpid-proton-core10-dev libqpid-proton11-dev libqpid-proton-proactor1-dev \
             uuid-dev libnss3-dev libnss3-tools libsasl2-dev sasl2-bin swig3.0 python-dev valgrind ruby
           
           sccache_version=v0.4.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
             libboost-dev libboost-program-options-dev libboost-system-dev libboost-test-dev \
             libxqilla-dev libxerces-c-dev \
             libibverbs-dev librdmacm-dev \
-            libqpid-proton-core10-dev libqpid-proton11-dev libqpid-proton-proactor1 \
+            libqpid-proton11-dev libqpid-proton-core10 libqpid-proton-proactor1 \
             uuid-dev libnss3-dev libnss3-tools libsasl2-dev sasl2-bin swig3.0 python-dev valgrind ruby
           
           sccache_version=v0.4.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,7 @@ jobs:
             libboost-dev libboost-program-options-dev libboost-system-dev libboost-test-dev \
             libxqilla-dev libxerces-c-dev \
             libibverbs-dev librdmacm-dev \
+            libdb-dev \
             libqpid-proton11-dev libqpid-proton-core10 libqpid-proton-proactor1 \
             swig3.0 python-dev ruby2.6 ruby2.6-dev \
             uuid-dev libnss3-dev libnss3-tools libsasl2-dev sasl2-bin \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           Set-ExecutionPolicy RemoteSigned -Scope CurrentUser # Optional: Needed to run a remote script the first time
           iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
-          scoop install ninja sccache
+          scoop install aws ninja sccache
 
           vcpkg install boost-program-options boost-system boost-test boost-date-time boost-thread boost-chrono boost-format boost-ptr-container boost-assign boost-parameter boost-foreach boost-utility
           vcpkg integrate install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
             libqpid-proton11-dev libqpid-proton-core10 libqpid-proton-proactor1 \
             uuid-dev libnss3-dev libnss3-tools libsasl2-dev sasl2-bin swig3.0 python-dev valgrind ruby
 
-          # we don't support swig 4.0, it produces runtime errors when used 
+          # QPID-8606: we don't support swig 4.0, it produces runtime errors when used 
           sudo apt-get -yq remove swig4.0
 
           sccache_version=v0.4.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
             libboost-dev libboost-program-options-dev libboost-system-dev libboost-test-dev \
             libxqilla-dev libxerces-c-dev \
             libibverbs-dev librdmacm-dev \
-            libdb++-dev \
+            libdb++-dev libaio-dev \
             libqpid-proton11-dev libqpid-proton-core10 libqpid-proton-proactor1 \
             swig3.0 python-dev ruby2.6 ruby2.6-dev \
             uuid-dev libnss3-dev libnss3-tools libsasl2-dev sasl2-bin \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # get swig 3 on linux
         os: [ ubuntu-20.04, windows-latest ]
         buildType: [ RelWithDebInfo ]
         include:
+          - os: ubuntu-20.04
+            # QPID-8606: we don't support swig 4.0, it produces runtime errors when used
+            cmake_extra: '-DSWIG_EXECUTABLE=/usr/bin/swig3.0'
           - os: windows-latest
             cmake_extra: '-DQPID_LINK_BOOST_DYNAMIC=OFF -DBUILD_BINDING_DOTNET=OFF -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake'
     env:
@@ -51,9 +53,6 @@ jobs:
           # ubuntu packages (https://packages.ubuntu.com/source/focal/qpid-proton) don't carry ProtonConfig.cmake
           # the `testing` ppa is less likely to be out-of-date
           sudo add-apt-repository ppa:qpid/testing && sudo apt-get update
-
-          # QPID-8606: we don't support swig 4.0, it produces runtime errors when used 
-          sudo apt-get -yq remove swig4.0
 
           sudo apt-get -yq --no-install-suggests --no-install-recommends install \
             cmake ninja-build \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,8 +128,9 @@ jobs:
           Add-Content ${env:GITHUB_PATH} "${HOME}/scoop/shims"
           
           # work around assumptions in our build scripts about boost layout
-          Copy-Item -Path C:/vcpkg/installed/x64-windows/debug/bin/ -Include "*.dll" -Destination C:/vcpkg/installed/x64-windows/debug/lib/
+          Copy-Item -Path C:/vcpkg/installed/x64-windows/debug/bin/* -Include "*.dll" -Destination C:/vcpkg/installed/x64-windows/debug/lib/
           
+          ls C:/vcpkg/installed/x64-windows/debug/bin/
           ls C:/vcpkg/installed/x64-windows/debug/lib/
         shell: pwsh
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,6 +129,8 @@ jobs:
           
           # work around assumptions in our build scripts about boost layout
           Copy-Item -Path C:/vcpkg/installed/x64-windows/debug/bin/ -Include "*.dll" -Destination C:/vcpkg/installed/x64-windows/debug/lib/
+          
+          ls C:/vcpkg/installed/x64-windows/debug/lib/
         shell: pwsh
 
       # Windows build should ideally use something like '-G "Visual Studio 16 2019" -A x64',

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           Set-ExecutionPolicy RemoteSigned -Scope CurrentUser # Optional: Needed to run a remote script the first time
           iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
-          scoop install aws ninja sccache
+          scoop install ninja sccache
 
           vcpkg install boost-program-options boost-system boost-test boost-date-time boost-thread boost-chrono boost-format boost-ptr-container boost-assign boost-parameter boost-foreach boost-utility
           vcpkg integrate install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,6 @@ jobs:
       - name: cmake configure
         run: |
           cmake -S "${{github.workspace}}" -B "${{env.BuildDir}}" -G Ninja `
-            -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" `
             -DCMAKE_C_COMPILER_LAUNCHER="sccache" -DCMAKE_CXX_COMPILER_LAUNCHER="sccache" `
             "-DCMAKE_BUILD_TYPE=${{env.BuildType}}" `
             "-DCMAKE_INSTALL_PREFIX=${{env.InstallPrefix}}" `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           Set-ExecutionPolicy RemoteSigned -Scope CurrentUser # Optional: Needed to run a remote script the first time
           iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
-          scoop install ninja sccache
+          scoop install sccache
 
           vcpkg install boost-program-options boost-system boost-test boost-date-time boost-thread boost-chrono boost-format boost-ptr-container boost-assign boost-parameter boost-foreach boost-utility
           vcpkg integrate install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
             libibverbs-dev librdmacm-dev \
             libqpid-proton11-dev libqpid-proton-core10 libqpid-proton-proactor1 \
             uuid-dev libnss3-dev libnss3-tools libsasl2-dev sasl2-bin swig3.0 python-dev valgrind ruby
-          
+
           sccache_version=v0.4.1
           wget -q https://github.com/mozilla/sccache/releases/download/${sccache_version}/sccache-${sccache_version}-x86_64-unknown-linux-musl.tar.gz
           tar -xf sccache-${sccache_version}-x86_64-unknown-linux-musl.tar.gz sccache-${sccache_version}-x86_64-unknown-linux-musl/sccache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
             # QPID-8606: we don't support swig 4.0, it produces runtime errors when used
             cmake_extra: '-DSWIG_EXECUTABLE=/usr/bin/swig3.0'
           - os: windows-latest
-            cmake_extra: '-DQPID_LINK_BOOST_DYNAMIC=OFF -DBUILD_BINDING_DOTNET=OFF -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake'
+            cmake_extra: '-DBUILD_BINDING_DOTNET=OFF -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake'
     env:
       BuildType: ${{matrix.buildType}}
       BuildDir: ${{github.workspace}}/BLD

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
           Add-Content ${env:GITHUB_PATH} "${HOME}/scoop/shims"
           
           # work around assumptions in our build scripts about boost layout
-          Copy-Item -Path C:/vcpkg/installed/x64-windows/debug/bin/* -Include *.dll -Destination C:/vcpkg/installed/x64-windows/debug/lib/
+          Copy-Item -Path C:/vcpkg/installed/x64-windows/debug/bin/* -Include *.dll -Destination C:/vcpkg/installed/x64-windows/debug/lib
           
           ls C:/vcpkg/installed/x64-windows/debug/bin/
           ls C:/vcpkg/installed/x64-windows/debug/lib/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
             libboost-dev libboost-program-options-dev libboost-system-dev libboost-test-dev \
             libxqilla-dev libxerces-c-dev \
             libibverbs-dev librdmacm-dev \
-            libqpid-proton11-dev \
+            libqpid-proton-core10-dev libqpid-proton11-dev \
             uuid-dev libnss3-dev libnss3-tools libsasl2-dev sasl2-bin swig3.0 python-dev valgrind ruby
           
           sccache_version=v0.4.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,10 +127,10 @@ jobs:
           # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#add-a-system-path-add-path
           Add-Content ${env:GITHUB_PATH} "${HOME}/scoop/shims"
           
-          # work around assumptions in our build scripts about boost layout
+          # work around assumptions in our build scripts about boost libs layout
           Copy-Item -Path C:/vcpkg/installed/x64-windows/debug/bin/* -Include *.dll -Destination C:/vcpkg/installed/x64-windows/debug/lib
-          Get-Item C:/vcpkg/installed/x64-windows/debug/lib/*.dll | Rename-Item -NewName { $_.Name -replace '-x64-1_81.dll','.dll' }
-          
+          Get-Item C:/vcpkg/installed/x64-windows/debug/lib/*.dll | Rename-Item -NewName { $_.Name -replace '-vc14*-gd-x64-1_81.dll','-vc140-mt-gd.dll' }
+          # display results of this hard work
           ls C:/vcpkg/installed/x64-windows/debug/bin/
           ls C:/vcpkg/installed/x64-windows/debug/lib/
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,7 @@ jobs:
           ls C:/vcpkg/installed/x64-windows/
           ls C:/vcpkg/installed/x64-windows/debug/
           ls C:/vcpkg/installed/x64-windows/debug/lib/
+          ls C:/vcpkg/installed/x64-windows/debug/bin/
           ls C:/vcpkg/installed/x64-windows/debug/lib/boost_date_time-vc140-mt-gd.dll
         shell: pwsh
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/cache@v3
         if: runner.os == 'Windows'
         with:
-          path: $HOME\scoop
+          path: ~\scoop
           key: ${{ runner.os }}-scoop-${{ env.OS_VER }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-scoop-${{ env.OS_VER }}-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,9 @@ jobs:
             libqpid-proton11-dev libqpid-proton-core10 libqpid-proton-proactor1 \
             uuid-dev libnss3-dev libnss3-tools libsasl2-dev sasl2-bin swig3.0 python-dev valgrind ruby
 
+          # we don't support swig 4.0, it produces runtime errors when used 
+          sudo apt-get -yq remove swig4.0
+
           sccache_version=v0.4.1
           wget -q https://github.com/mozilla/sccache/releases/download/${sccache_version}/sccache-${sccache_version}-x86_64-unknown-linux-musl.tar.gz
           tar -xf sccache-${sccache_version}-x86_64-unknown-linux-musl.tar.gz sccache-${sccache_version}-x86_64-unknown-linux-musl/sccache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,8 @@ jobs:
         os: [ ubuntu-20.04, windows-latest ]
         buildType: [ RelWithDebInfo ]
         include:
-          - os: ubuntu-20.04
-            cmake_generator: '-G "Ninja"'
           - os: windows-latest
             cmake_extra: '-DBUILD_BINDING_DOTNET=OFF -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake'
-            cmake_generator: '-G "Visual Studio 16 2019" -A x64'
     env:
       BuildType: ${{matrix.buildType}}
       BuildDir: ${{github.workspace}}/BLD
@@ -109,6 +106,8 @@ jobs:
           Add-Content ${env:GITHUB_PATH} "${HOME}/scoop/shims"
         shell: pwsh
 
+      # Windows build should ideally use something like '-G "Visual Studio 16 2019" -A x64',
+      #  but -DCMAKE_C_COMPILER_LAUNCHER is only supported by make and ninja generators
       # https://devblogs.microsoft.com/scripting/powertip-line-continuation-in-powershell/
       - name: cmake configure
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,6 +129,9 @@ jobs:
           
           # work around assumptions in our build scripts about boost layout
           Copy-Item -Path C:/vcpkg/installed/x64-windows/debug/bin/* -Include "*.dll" -Destination C:/vcpkg/installed/x64-windows/debug/lib/
+          
+          ls C:/vcpkg/installed/x64-windows/debug/bin/
+          ls C:/vcpkg/installed/x64-windows/debug/lib/
         shell: pwsh
 
       # Windows build should ideally use something like '-G "Visual Studio 16 2019" -A x64',

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,6 +129,7 @@ jobs:
           
           # work around assumptions in our build scripts about boost layout
           Copy-Item -Path C:/vcpkg/installed/x64-windows/debug/bin/* -Include *.dll -Destination C:/vcpkg/installed/x64-windows/debug/lib
+          Get-Item C:/vcpkg/installed/x64-windows/debug/lib/*.dll | Rename-Item -NewName { $_.Name -replace '-x64-1_81.dll','.dll' }
           
           ls C:/vcpkg/installed/x64-windows/debug/bin/
           ls C:/vcpkg/installed/x64-windows/debug/lib/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,11 +52,14 @@ jobs:
             cmake ninja-build \
             libboost-dev libboost-program-options-dev libboost-system-dev libboost-test-dev \
             libxqilla-dev libxerces-c-dev \
+            libibverbs-dev librdmacm-dev \
             libqpid-proton11-dev libqpid-proton-cpp12-dev \
             uuid-dev libnss3-dev libnss3-tools libsasl2-dev sasl2-bin swig3.0 python-dev valgrind ruby
-          wget -q https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz
-          tar -xf sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz sccache-v0.3.0-x86_64-unknown-linux-musl/sccache
-          sudo mv sccache-v0.3.0-x86_64-unknown-linux-musl/sccache /usr/bin/sccache
+          
+          sccache_version=v0.4.1
+          wget -q https://github.com/mozilla/sccache/releases/download/${sccache_version}/sccache-${sccache_version}-x86_64-unknown-linux-musl.tar.gz
+          tar -xf sccache-${sccache_version}-x86_64-unknown-linux-musl.tar.gz sccache-${sccache_version}-x86_64-unknown-linux-musl/sccache
+          sudo mv sccache-${sccache_version}-x86_64-unknown-linux-musl/sccache /usr/bin/sccache
           sudo chmod +x /usr/bin/sccache
         shell: bash
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
           sudo mv sccache-v0.3.0-x86_64-unknown-linux-musl/sccache /usr/bin/sccache
           sudo chmod +x /usr/bin/sccache
 
-      - name: Cache scoop directory (on Windows)
+      - name: Cache scoop (on Windows)
         uses: actions/cache@v3
         if: runner.os == 'Windows'
         with:
@@ -64,7 +64,7 @@ jobs:
             ${{ runner.os }}-scoop-${{ env.OS_VER }}-
             ${{ runner.os }}-scoop-
 
-      - name: Cache vcpkg downloads (on Windows)
+      - name: Cache vcpkg/downloads (on Windows)
         uses: actions/cache@v3
         if: runner.os == 'Windows'
         with:
@@ -73,7 +73,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-vcpkg-download-${{ env.OS_VER }}-
             ${{ runner.os }}-vcpkg-download-
-      - name: Cache vcpkg installed (on Windows)
+      - name: Cache vcpkg/installed (on Windows)
         uses: actions/cache@v3
         if: runner.os == 'Windows'
         with:
@@ -83,7 +83,7 @@ jobs:
             ${{ runner.os }}-vcpkg-installed-${{ matrix.os }}-
             ${{ runner.os }}-vcpkg-installed-
 
-      - name: Cache sccache
+      - name: Cache SCCACHE_DIR
         uses: actions/cache@v3
         with:
           path: "${{ env.SCCACHE_DIR }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,7 +157,7 @@ jobs:
       # https://github.com/jiridanek/qpid-cpp/actions/runs/3314156604/jobs/5473066487#step:12:1472
       - name: cmake build/install
         run: |
-          cmake --build "${{env.BuildDir}}" --config ${{env.BuildType}}
+          cmake --build "${{env.BuildDir}}" --config ${{env.BuildType}} -- -v
           cmake --install "${{env.BuildDir}}" --config ${{env.BuildType}}
         shell: pwsh
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,9 @@ jobs:
           # the `testing` ppa is less likely to be out-of-date
           sudo add-apt-repository ppa:qpid/testing && sudo apt-get update
 
+          # QPID-8606: we don't support swig 4.0, it produces runtime errors when used 
+          sudo apt-get -yq remove swig4.0
+
           sudo apt-get -yq --no-install-suggests --no-install-recommends install \
             cmake ninja-build \
             libboost-dev libboost-program-options-dev libboost-system-dev libboost-test-dev \
@@ -59,9 +62,6 @@ jobs:
             libibverbs-dev librdmacm-dev \
             libqpid-proton11-dev libqpid-proton-core10 libqpid-proton-proactor1 \
             uuid-dev libnss3-dev libnss3-tools libsasl2-dev sasl2-bin swig3.0 python-dev valgrind ruby
-
-          # QPID-8606: we don't support swig 4.0, it produces runtime errors when used 
-          sudo apt-get -yq remove swig4.0
 
           sccache_version=v0.4.1
           wget -q https://github.com/mozilla/sccache/releases/download/${sccache_version}/sccache-${sccache_version}-x86_64-unknown-linux-musl.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
             libboost-dev libboost-program-options-dev libboost-system-dev libboost-test-dev \
             libxqilla-dev libxerces-c-dev \
             libibverbs-dev librdmacm-dev \
-            libqpid-proton-core10-dev libqpid-proton11-dev libqpid-proton-proactor1-dev \
+            libqpid-proton-core10-dev libqpid-proton11-dev libqpid-proton-proactor1 \
             uuid-dev libnss3-dev libnss3-tools libsasl2-dev sasl2-bin swig3.0 python-dev valgrind ruby
           
           sccache_version=v0.4.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
           vcpkg integrate install
 
           # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#add-a-system-path-add-path
-          echo "${HOME}/scoop/shims" | Out-File -FilePath ${env:GITHUB_PATH} -Encoding utf8 -Append
+          Add-Content ${env:GITHUB_PATH} "${HOME}/scoop/shims"
         shell: pwsh
 
       # https://devblogs.microsoft.com/scripting/powertip-line-continuation-in-powershell/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
         include:
           - os: ubuntu-20.04
             # QPID-8606: we don't support swig 4.0, it produces runtime errors when used
-            cmake_extra: '-DSWIG_EXECUTABLE="/usr/bin/swig3.0"'
+            cmake_extra: '-DSWIG_EXECUTABLE="/usr/bin/swig3.0" -DRUBY_EXECUTABLE="/usr/bin/ruby2.6"'
           - os: windows-latest
             cmake_extra: '-DBUILD_BINDING_DOTNET=OFF -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake'
     env:
@@ -64,7 +64,7 @@ jobs:
             libxqilla-dev libxerces-c-dev \
             libibverbs-dev librdmacm-dev \
             libqpid-proton11-dev libqpid-proton-core10 libqpid-proton-proactor1 \
-            swig3.0 python-dev ruby2.6-dev \
+            swig3.0 python-dev ruby2.6 ruby2.6-dev \
             uuid-dev libnss3-dev libnss3-tools libsasl2-dev sasl2-bin \
             valgrind 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,18 +139,18 @@ jobs:
           cmake --install "${{env.BuildDir}}" --config ${{env.BuildType}}
         shell: pwsh
 
-#      - id: ctest
-#        name: ctest
-#        working-directory: ${{env.BuildDir}}
-#        run: PYTHONPATH=${InstallPrefix}/lib/python2.7/site-packages ctest -C ${BuildType} -V -T Test --no-compress-output ${{matrix.ctest_extra}}
-#        shell: bash
-#
-#      - name: Upload Test results
-#        if: always() && (steps.ctest.outcome == 'failure' || steps.ctest.outcome == 'success')
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: Test_Results_${{matrix.os}}_${{matrix.buildType}}
-#          path: ${{env.BuildDir}}/Testing/**/*.xml
+      - id: ctest
+        name: ctest
+        working-directory: ${{env.BuildDir}}
+        run: PYTHONPATH=${InstallPrefix}/lib/python2.7/site-packages ctest -C ${BuildType} -V -T Test --no-compress-output ${{matrix.ctest_extra}}
+        shell: bash
+
+      - name: Upload Test results
+        if: always() && (steps.ctest.outcome == 'failure' || steps.ctest.outcome == 'success')
+        uses: actions/upload-artifact@v3
+        with:
+          name: Test_Results_${{matrix.os}}_${{matrix.buildType}}
+          path: ${{env.BuildDir}}/Testing/**/*.xml
 
       - name: Environment
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,6 +133,12 @@ jobs:
           # display results of this hard work
           ls C:/vcpkg/installed/x64-windows/debug/bin/
           ls C:/vcpkg/installed/x64-windows/debug/lib/
+          # now do the same for release
+          Copy-Item -Path C:/vcpkg/installed/x64-windows/bin/* -Include *.dll -Destination C:/vcpkg/installed/x64-windows/lib
+          Get-Item C:/vcpkg/installed/x64-windows/lib/*.dll | Rename-Item -NewName { $_.Name -replace '-vc14.-mt-x64-1_81.dll','-vc140-mt.dll' }
+          # display results of this hard work
+          ls C:/vcpkg/installed/x64-windows/bin/
+          ls C:/vcpkg/installed/x64-windows/lib/
         shell: pwsh
 
       # Windows build should ideally use something like '-G "Visual Studio 16 2019" -A x64',

--- a/CTestCustom.cmake
+++ b/CTestCustom.cmake
@@ -1,1 +1,1 @@
-set(CTEST_CUSTOM_PRE_TEST "${PYTHON_EXECUTABLE} ${CMAKE_BINARY_DIR}/src/tests/check_dependencies.py")
+set(CTEST_CUSTOM_PRE_TEST "${CMAKE_BINARY_DIR}/src/tests/check_dependencies.py")

--- a/CTestCustom.cmake
+++ b/CTestCustom.cmake
@@ -1,1 +1,1 @@
-set(CTEST_CUSTOM_PRE_TEST "${CMAKE_BINARY_DIR}/src/tests/check_dependencies.py")
+set(CTEST_CUSTOM_PRE_TEST "${PYTHON_EXECUTABLE} ${CMAKE_BINARY_DIR}/src/tests/check_dependencies.py")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -28,8 +28,8 @@ include_directories(${CMAKE_SOURCE_DIR}/include)
 # So set up to find the headers, find the libs at link time, but dynamically
 # link them all and clear the CMake Boost library names to avoid adding them to
 # the project files.
-#include_directories( ${Boost_INCLUDE_DIR} )
-#link_directories( ${Boost_LIBRARY_DIRS} )
+include_directories( ${Boost_INCLUDE_DIR} )
+link_directories( ${Boost_LIBRARY_DIRS} )
 
 # Visual Studio needs some Windows-specific simplifications.
 if (MSVC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -288,6 +288,8 @@ include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/../include )
 include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
 include_directories( ${CMAKE_CURRENT_BINARY_DIR}/../include )
 
+link_directories( ${Boost_LIBRARY_DIRS} )
+
 CHECK_SYMBOL_EXISTS(uuid_generate "uuid/uuid.h" UUID_GENERATE_IN_LIBC)
 if (UUID_GENERATE_IN_LIBC)
   set(uuid_SRC "")
@@ -575,8 +577,7 @@ if (BUILD_HA)
     target_link_libraries (ha
                            PRIVATE
                            qpidtypes qpidcommon qpidbroker qpidmessaging
-                           ${Boost_PROGRAM_OPTIONS_LIBRARY}
-                           ${Boost_THREAD_LIBRARY})
+                           ${Boost_PROGRAM_OPTIONS_LIBRARY})
     set_target_properties (ha PROPERTIES
                            PREFIX "")
     install (TARGETS ha
@@ -936,8 +937,7 @@ add_msvc_version (qpidclient library dll)
 add_library (qpidclient SHARED ${qpidclient_SOURCES})
 
 target_link_libraries (qpidclient PRIVATE qpidcommon qpidtypes
-                       ${ssl_LIBS}
-                       ${Boost_THREAD_LIBRARY})
+                       ${ssl_LIBS})
 
 set_target_properties (qpidclient PROPERTIES
                        VERSION ${qpidclient_version}
@@ -1004,7 +1004,7 @@ set (qpidmessaging_SOURCES
 add_msvc_version (qpidmessaging library dll)
 
 add_library (qpidmessaging SHARED ${qpidmessaging_SOURCES})
-target_link_libraries (qpidmessaging PRIVATE qpidtypes qpidclient qpidcommon ${Proton_Core_LIBRARIES} ${Boost_THREAD_LIBRARY})
+target_link_libraries (qpidmessaging PRIVATE qpidtypes qpidclient qpidcommon ${Proton_Core_LIBRARIES})
 set_target_properties (qpidmessaging PROPERTIES
                        LINK_FLAGS "${HIDE_SYMBOL_FLAGS} ${LINK_VERSION_SCRIPT_FLAG}"
                        COMPILE_FLAGS "${HIDE_SYMBOL_FLAGS}"
@@ -1141,8 +1141,7 @@ target_link_libraries (qpidbroker
                        PRIVATE
                        qpidcommon qpidtypes
                        "${sasl_LIB}"
-                       ${ssl_server_LIBS}
-                       ${Boost_THREAD_LIBRARY})
+                       ${ssl_server_LIBS})
 
 set_target_properties (qpidbroker PROPERTIES
                        VERSION ${qpidbroker_version}
@@ -1257,7 +1256,7 @@ endif (NOT WIN32)
 
     add_msvc_version (qmf2 library dll)
     add_library (qmf2 SHARED ${qmf2_SOURCES})
-    target_link_libraries (qmf2 PRIVATE qpidmessaging qpidtypes qpidclient qpidcommon ${Boost_THREAD_LIBRARY})
+    target_link_libraries (qmf2 PRIVATE qpidmessaging qpidtypes qpidclient qpidcommon)
     set_target_properties (qmf2 PROPERTIES
                            VERSION ${qmf2_version}
                            SOVERSION ${qmf2_version_major})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -281,6 +281,8 @@ include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/../include )
 include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
 include_directories( ${CMAKE_CURRENT_BINARY_DIR}/../include )
 
+link_directories( ${Boost_LIBRARY_DIRS} )
+
 CHECK_SYMBOL_EXISTS(uuid_generate "uuid/uuid.h" UUID_GENERATE_IN_LIBC)
 if (UUID_GENERATE_IN_LIBC)
   set(uuid_SRC "")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -288,8 +288,6 @@ include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/../include )
 include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
 include_directories( ${CMAKE_CURRENT_BINARY_DIR}/../include )
 
-link_directories( ${Boost_LIBRARY_DIRS} )
-
 CHECK_SYMBOL_EXISTS(uuid_generate "uuid/uuid.h" UUID_GENERATE_IN_LIBC)
 if (UUID_GENERATE_IN_LIBC)
   set(uuid_SRC "")
@@ -577,7 +575,8 @@ if (BUILD_HA)
     target_link_libraries (ha
                            PRIVATE
                            qpidtypes qpidcommon qpidbroker qpidmessaging
-                           ${Boost_PROGRAM_OPTIONS_LIBRARY})
+                           ${Boost_PROGRAM_OPTIONS_LIBRARY}
+                           ${Boost_THREAD_LIBRARY})
     set_target_properties (ha PROPERTIES
                            PREFIX "")
     install (TARGETS ha
@@ -937,7 +936,8 @@ add_msvc_version (qpidclient library dll)
 add_library (qpidclient SHARED ${qpidclient_SOURCES})
 
 target_link_libraries (qpidclient PRIVATE qpidcommon qpidtypes
-                       ${ssl_LIBS})
+                       ${ssl_LIBS}
+                       ${Boost_THREAD_LIBRARY})
 
 set_target_properties (qpidclient PROPERTIES
                        VERSION ${qpidclient_version}
@@ -1004,7 +1004,7 @@ set (qpidmessaging_SOURCES
 add_msvc_version (qpidmessaging library dll)
 
 add_library (qpidmessaging SHARED ${qpidmessaging_SOURCES})
-target_link_libraries (qpidmessaging PRIVATE qpidtypes qpidclient qpidcommon ${Proton_Core_LIBRARIES})
+target_link_libraries (qpidmessaging PRIVATE qpidtypes qpidclient qpidcommon ${Proton_Core_LIBRARIES} ${Boost_THREAD_LIBRARY})
 set_target_properties (qpidmessaging PROPERTIES
                        LINK_FLAGS "${HIDE_SYMBOL_FLAGS} ${LINK_VERSION_SCRIPT_FLAG}"
                        COMPILE_FLAGS "${HIDE_SYMBOL_FLAGS}"
@@ -1141,7 +1141,8 @@ target_link_libraries (qpidbroker
                        PRIVATE
                        qpidcommon qpidtypes
                        "${sasl_LIB}"
-                       ${ssl_server_LIBS})
+                       ${ssl_server_LIBS}
+                       ${Boost_THREAD_LIBRARY})
 
 set_target_properties (qpidbroker PROPERTIES
                        VERSION ${qpidbroker_version}
@@ -1256,7 +1257,7 @@ endif (NOT WIN32)
 
     add_msvc_version (qmf2 library dll)
     add_library (qmf2 SHARED ${qmf2_SOURCES})
-    target_link_libraries (qmf2 PRIVATE qpidmessaging qpidtypes qpidclient qpidcommon)
+    target_link_libraries (qmf2 PRIVATE qpidmessaging qpidtypes qpidclient qpidcommon ${Boost_THREAD_LIBRARY})
     set_target_properties (qmf2 PROPERTIES
                            VERSION ${qmf2_version}
                            SOVERSION ${qmf2_version_major})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -230,8 +230,7 @@ endif (BUILD_TESTING)
 # DLLs that are needed for the Windows package, none are needed for the
 # static link case; else drop them into the install. Do this all first, since
 # Boost on Windows can use automatic linking to pick up the correct
-# Boost libs based on compile-time touching of the headers. Since we don't
-# really need to add them to the link lines, set the names to blanks.
+# Boost libs based on compile-time touching of the headers.
 option(QPID_LINK_BOOST_DYNAMIC "Link with dynamic Boost libs (OFF to link static)" ON)
 mark_as_advanced(QPID_LINK_BOOST_DYNAMIC)
 
@@ -272,12 +271,6 @@ if (MSVC)
                COMPONENT ${QPID_COMPONENT_COMMON})
    endif (QPID_LINK_BOOST_DYNAMIC)
 
-   set(Boost_DATE_TIME_LIBRARY "")
-   set(Boost_THREAD_LIBRARY "")
-   set(Boost_PROGRAM_OPTIONS_LIBRARY "")
-   set(Boost_UNIT_TEST_FRAMEWORK_LIBRARY "")
-   set(Boost_SYSTEM_LIBRARY "")
-   set(Boost_CHRONO_LIBRARY "")
    include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/windows/resources )
 endif (MSVC)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -272,6 +272,12 @@ if (MSVC)
                COMPONENT ${QPID_COMPONENT_COMMON})
    endif (QPID_LINK_BOOST_DYNAMIC)
 
+   set(Boost_DATE_TIME_LIBRARY "")
+   set(Boost_THREAD_LIBRARY "")
+   set(Boost_PROGRAM_OPTIONS_LIBRARY "")
+   set(Boost_UNIT_TEST_FRAMEWORK_LIBRARY "")
+   set(Boost_SYSTEM_LIBRARY "")
+   set(Boost_CHRONO_LIBRARY "")
    include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/windows/resources )
 endif (MSVC)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -272,12 +272,6 @@ if (MSVC)
                COMPONENT ${QPID_COMPONENT_COMMON})
    endif (QPID_LINK_BOOST_DYNAMIC)
 
-   set(Boost_DATE_TIME_LIBRARY "")
-   set(Boost_THREAD_LIBRARY "")
-   set(Boost_PROGRAM_OPTIONS_LIBRARY "")
-   set(Boost_UNIT_TEST_FRAMEWORK_LIBRARY "")
-   set(Boost_SYSTEM_LIBRARY "")
-   set(Boost_CHRONO_LIBRARY "")
    include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/windows/resources )
 endif (MSVC)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -262,22 +262,22 @@ if (MSVC)
         string (REPLACE .lib .dll
                 _boost_chrono_release ${Boost_CHRONO_LIBRARY_RELEASE})
       endif (NOT Boost_VERSION LESS 104700)
-#      install (PROGRAMS
-#               ${_boost_date_time_debug} ${_boost_date_time_release}
-#               ${_boost_program_options_debug} ${_boost_program_options_release}
-#               ${_boost_thread_debug} ${_boost_thread_release}
-#               ${_boost_chrono_debug} ${_boost_chrono_release}
-#               ${_boost_system_debug} ${_boost_system_release}
-#               DESTINATION ${QPID_INSTALL_BINDIR}
-#               COMPONENT ${QPID_COMPONENT_COMMON})
+      install (PROGRAMS
+               ${_boost_date_time_debug} ${_boost_date_time_release}
+               ${_boost_program_options_debug} ${_boost_program_options_release}
+               ${_boost_thread_debug} ${_boost_thread_release}
+               ${_boost_chrono_debug} ${_boost_chrono_release}
+               ${_boost_system_debug} ${_boost_system_release}
+               DESTINATION ${QPID_INSTALL_BINDIR}
+               COMPONENT ${QPID_COMPONENT_COMMON})
    endif (QPID_LINK_BOOST_DYNAMIC)
 
-#   set(Boost_DATE_TIME_LIBRARY "")
-#   set(Boost_THREAD_LIBRARY "")
-#   set(Boost_PROGRAM_OPTIONS_LIBRARY "")
-#   set(Boost_UNIT_TEST_FRAMEWORK_LIBRARY "")
-#   set(Boost_SYSTEM_LIBRARY "")
-#   set(Boost_CHRONO_LIBRARY "")
+   set(Boost_DATE_TIME_LIBRARY "")
+   set(Boost_THREAD_LIBRARY "")
+   set(Boost_PROGRAM_OPTIONS_LIBRARY "")
+   set(Boost_UNIT_TEST_FRAMEWORK_LIBRARY "")
+   set(Boost_SYSTEM_LIBRARY "")
+   set(Boost_CHRONO_LIBRARY "")
    include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/windows/resources )
 endif (MSVC)
 
@@ -287,8 +287,6 @@ include_directories( ${CMAKE_CURRENT_SOURCE_DIR} )
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/../include )
 include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
 include_directories( ${CMAKE_CURRENT_BINARY_DIR}/../include )
-
-#link_directories( ${Boost_LIBRARY_DIRS} )
 
 CHECK_SYMBOL_EXISTS(uuid_generate "uuid/uuid.h" UUID_GENERATE_IN_LIBC)
 if (UUID_GENERATE_IN_LIBC)

--- a/src/qpid/store/CMakeLists.txt
+++ b/src/qpid/store/CMakeLists.txt
@@ -21,8 +21,6 @@ project(qpidc_store)
 
 #set (CMAKE_VERBOSE_MAKEFILE ON)  # for debugging
 
-#include_directories( ${Boost_INCLUDE_DIR} )
-
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR} )
 include_directories( ${CMAKE_HOME_DIRECTORY}/include )
 

--- a/src/qpid/store/CMakeLists.txt
+++ b/src/qpid/store/CMakeLists.txt
@@ -21,6 +21,8 @@ project(qpidc_store)
 
 #set (CMAKE_VERBOSE_MAKEFILE ON)  # for debugging
 
+include_directories( ${Boost_INCLUDE_DIR} )
+
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR} )
 include_directories( ${CMAKE_HOME_DIRECTORY}/include )
 
@@ -78,7 +80,7 @@ if (BUILD_MSSQL)
                ms-sql/State.cpp
                ms-sql/TplRecordset.cpp
                ms-sql/VariantHelper.cpp)
-  target_link_libraries (mssql_store qpidbroker qpidcommon ${Boost_THREAD_LIBRARY})
+  target_link_libraries (mssql_store qpidbroker qpidcommon)
   install (TARGETS mssql_store # RUNTIME
            DESTINATION ${QPIDD_MODULE_DIR}
            COMPONENT ${QPID_COMPONENT_BROKER})
@@ -107,7 +109,7 @@ if (BUILD_MSCLFS)
                ms-sql/State.cpp
                ms-sql/VariantHelper.cpp)
   include_directories(ms-sql)
-  target_link_libraries (msclfs_store qpidbroker qpidcommon clfsw32.lib ${Boost_THREAD_LIBRARY})
+  target_link_libraries (msclfs_store qpidbroker qpidcommon clfsw32.lib)
   install (TARGETS msclfs_store # RUNTIME
            DESTINATION ${QPIDD_MODULE_DIR}
            COMPONENT ${QPID_COMPONENT_BROKER})

--- a/src/qpid/store/CMakeLists.txt
+++ b/src/qpid/store/CMakeLists.txt
@@ -21,8 +21,6 @@ project(qpidc_store)
 
 #set (CMAKE_VERBOSE_MAKEFILE ON)  # for debugging
 
-include_directories( ${Boost_INCLUDE_DIR} )
-
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR} )
 include_directories( ${CMAKE_HOME_DIRECTORY}/include )
 
@@ -80,7 +78,7 @@ if (BUILD_MSSQL)
                ms-sql/State.cpp
                ms-sql/TplRecordset.cpp
                ms-sql/VariantHelper.cpp)
-  target_link_libraries (mssql_store qpidbroker qpidcommon)
+  target_link_libraries (mssql_store qpidbroker qpidcommon ${Boost_THREAD_LIBRARY})
   install (TARGETS mssql_store # RUNTIME
            DESTINATION ${QPIDD_MODULE_DIR}
            COMPONENT ${QPID_COMPONENT_BROKER})
@@ -109,7 +107,7 @@ if (BUILD_MSCLFS)
                ms-sql/State.cpp
                ms-sql/VariantHelper.cpp)
   include_directories(ms-sql)
-  target_link_libraries (msclfs_store qpidbroker qpidcommon clfsw32.lib)
+  target_link_libraries (msclfs_store qpidbroker qpidcommon clfsw32.lib ${Boost_THREAD_LIBRARY})
   install (TARGETS msclfs_store # RUNTIME
            DESTINATION ${QPIDD_MODULE_DIR}
            COMPONENT ${QPID_COMPONENT_BROKER})

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -161,7 +161,7 @@ if (BUILD_TESTING_UNITTESTS)
 
 # Like this to work with cmake 2.4 on Unix
 set(qpid_test_boost_libs
-    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY})
+    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
 set(all_unit_tests
     AccumulatedAckTest

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -161,7 +161,7 @@ if (BUILD_TESTING_UNITTESTS)
 
 # Like this to work with cmake 2.4 on Unix
 set(qpid_test_boost_libs
-    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_SYSTEM_LIBRARY})
+    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY})
 
 set(all_unit_tests
     AccumulatedAckTest

--- a/src/tests/legacystore/CMakeLists.txt
+++ b/src/tests/legacystore/CMakeLists.txt
@@ -32,7 +32,7 @@ if (BUILD_TESTING_UNITTESTS)
 
 # Like this to work with cmake 2.4 on Unix
 set (qpid_test_boost_libs
-     ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_SYSTEM_LIBRARY})
+     ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY})
 
 # Journal tests
 MACRO (define_journal_test mainSourceFile)

--- a/src/tests/legacystore/CMakeLists.txt
+++ b/src/tests/legacystore/CMakeLists.txt
@@ -32,7 +32,7 @@ if (BUILD_TESTING_UNITTESTS)
 
 # Like this to work with cmake 2.4 on Unix
 set (qpid_test_boost_libs
-     ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY})
+     ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
 # Journal tests
 MACRO (define_journal_test mainSourceFile)


### PR DESCRIPTION
Github Actions don't run on the PR, so I am monitoring it on my fork, https://github.com/jiridanek/qpid-cpp/actions/runs/4644235028

Using Focal (`runs-on: ubuntu-20.04`) for now, as it has the old requirements we need. Travis used to run Xenial, that worked even better, without workarounds for swig and ruby.

Python 2.7 is required ([QPID-8516](https://issues.apache.org/jira/browse/QPID-8516), [QPID-4982](https://issues.apache.org/jira/browse/QPID-4982), [QPID-8517](https://issues.apache.org/jira/browse/QPID-8517))

Linux environment requires swig3.0 and ruby2.6 to compile and work ([QPID-8606](https://issues.apache.org/jira/browse/QPID-8606), https://github.com/swig/swig/issues/1689)

The vcpkg version of Boost requires some changes to how dependencies are linked. What's in the PR now works on both Appveyor and Github Actions.

Caching is very important. Both installing boost with vcpkg on Windows and compiling the broker code takes a lot of time without cache. With cache, vcpkg is nearly instantaneous and broker compile takes only a few minutes on Linux, and few more on Windows. When using sccache, make or ninja CMake generators have to be used. MSBuild is not supported for `-DCMAKE_C_COMPILER_LAUNCHER` CMake option. This can be workarounded in the future by the usual trick of renaming `sccache.exe` to `cl.exe`.

Tests run very long. I am afraid to run them in parallel as part of this PR. I want to leave that for later. But it is going to be necessary, because the CI just takes way too much time otherwise.

Broker tests don't run on Windows and AFAIK they did not run there for a very long time.