### PR TITLE
flags declaration (not definition) in  QpidDllMain.h

### DIFF
--- a/src/qpid/sys/windows/QpidDllMain.h
+++ b/src/qpid/sys/windows/QpidDllMain.h
@@ -39,8 +39,8 @@ namespace qpid {
 namespace sys {
 namespace windows {
 
-QPID_IMPORT bool processExiting;
-QPID_IMPORT bool libraryUnloading;
+QPID_IMPORT extern bool processExiting;
+QPID_IMPORT extern bool libraryUnloading;
 
 }}} // namespace qpid::sys::SystemInfo
 


### PR DESCRIPTION
These flags are already defined in https://github.com/apache/qpid-cpp/blob/62aaa4cd11b960d6303e55ba0c0ef3289e07c974/src/qpid/sys/windows/SystemInfo.cpp